### PR TITLE
Improve geopoint, add more and proper tests for it

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -32,7 +32,7 @@ class Color implements JsonSerializable
      *
      * @ORM\Column(type="string", length=6, nullable=true)
      * 
-     * @var array
+     * @var string
      */
     private $color;
 
@@ -43,8 +43,12 @@ class Color implements JsonSerializable
      * 
      * @param string $hex
      */
-    public function __construct($hex)
+    public function __construct($hex = null)
     {
+        if ($hex === null) {
+            return;
+        }
+        
         $hex = $this->normalize($hex);
 
         if (!$this->isValidHex($hex)) {
@@ -61,16 +65,20 @@ class Color implements JsonSerializable
      */
     public function toHex()
     {
-        return '#'.$this->color;
+        return ($this->color) ? '#'.$this->color : '';
     }
 
     /**
-     * Returns the color in RGB format
+     * Returns the color in RGB format, empty array if color is not set.
      *
      * @return array
      */
     public function toRGB()
     {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
         list($r, $g, $b) = sscanf($this->color, "%02x%02x%02x");
 
         return [ $r, $g, $b ];
@@ -115,6 +123,10 @@ class Color implements JsonSerializable
      */
     public function toArray()
     {
+        if ($this->isEmpty()) {
+            return [];
+        }
+        
         $rgb = $this->toRGB();
 
         return [
@@ -158,6 +170,16 @@ class Color implements JsonSerializable
     public function __toString()
     {
         return $this->toHex();
+    }
+
+    /**
+     * Returns a boolean TRUE if color is literally empty
+     * 
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return empty($this->color);
     }
 
     /**

--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -41,9 +41,11 @@ class DateRange implements JsonSerializable
      * @param \DateTime $start
      * @param \DateTime $end
      */
-    public function __construct(\DateTime $start, \DateTime $end)
+    public function __construct(\DateTime $start = null, \DateTime $end = null)
     {
-        if ($start >= $end) {
+        if ($start === null || $end === null) {
+            return;
+        } elseif ($start >= $end) {
             throw new \InvalidArgumentException('Start date is greater or equal to end date');
         }
         
@@ -80,6 +82,10 @@ class DateRange implements JsonSerializable
      */
     public function format($f = 'c')
     {
+        if ($this->isEmpty()) {
+            return '';
+        }
+
         return $this->getDateFrom()->format($f).' - '.$this->getDateTo()->format($f);
     }
 
@@ -90,7 +96,7 @@ class DateRange implements JsonSerializable
      */
     public function __toString()
     {
-        return $this->getDateFrom()->format('c').' - '.$this->getDateTo()->format('c');
+        return $this->format('c');
     }
 
     /**
@@ -100,6 +106,10 @@ class DateRange implements JsonSerializable
      */
     public function getDurationInSeconds()
     {
+        if (!$this->dateFrom) {
+            return 0;
+        }
+
         $interval = $this->dateFrom->diff($this->dateTo);
 
         return ($interval->y * 365 * 24 * 60 * 60) +
@@ -115,11 +125,15 @@ class DateRange implements JsonSerializable
      * 
      * @return array
      */
-    public function toArray()
+    public function toArray($format = 'c')
     {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
         return [
-            'start' => $this->dateFrom,
-            'end'   => $this->dateTo,
+            'start' => $this->getDateFrom()->format($format),
+            'end'   => $this->getDateTo()->format($format),
         ];
     }
 
@@ -131,5 +145,16 @@ class DateRange implements JsonSerializable
     public function jsonSerialize()
     {
         return $this->toArray();
+    }
+
+    /**
+     * Returns a boolean TRUE if the range instance is
+     * literally empty, FALSE otherwise.
+     * 
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return !$this->dateFrom || !$this->dateTo;
     }
 }

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -30,11 +30,11 @@ class EmailAddress
      * 
      * @param string $email E-mail address
      */
-    public function __construct($email)
+    public function __construct($email = null)
     {
-        // This is only a soft validation.
+        // This is only a soft validation to reduce headaches in
         // You SHOULD sanitize & validate email before using it as a value object!
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if ($email && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw new \InvalidArgumentException('Given e-mail address '.$email.' is not a valid');
         }
 
@@ -58,7 +58,7 @@ class EmailAddress
      */
     public function getDomain()
     {
-        return explode('@', $this->address)[1];
+        return $this->address ? explode('@', $this->address)[1] : null;
     }
 
     /**
@@ -68,6 +68,6 @@ class EmailAddress
      */
     public function getLocalPart()
     {
-        return explode('@', $this->address)[0];
+        return $this->address ? explode('@', $this->address)[0] : null;
     }
 }

--- a/src/Fullname.php
+++ b/src/Fullname.php
@@ -90,9 +90,11 @@ class Fullname implements JsonSerializable
      * @param string $fullname Space separated full name. Ex: Steven Paul Jobs
      * @param string $title
      */
-    public function __construct($fullname, $title = null)
+    public function __construct($fullname = null, $title = null)
     {
-        $this->buildFromString($fullname);
+        if($fullname) {
+            $this->buildFromString($fullname);
+        }
 
         if ($title) {
             $this->setTitle($title);

--- a/src/GeoPoint.php
+++ b/src/GeoPoint.php
@@ -32,30 +32,24 @@ class GeoPoint implements JsonSerializable
      * @param float $lat Latitude
      * @param float $lng Longitude
      */
-    public function __construct($lat, $lng)
+    public function __construct($lat = 0, $lng = 0)
     {
         if ($lat < -90.0 || $lat > 90.0 || $lng < -180.0 || $lng > 180.0) {
             throw new \InvalidArgumentException('Given latitude longitude pair is invalid.');
         }
-        
-        $this->point = [
-            'lat' => (float) $lat,
-            'lng' => (float) $lng,
-        ];
-    }
 
-    /**
-     * Gets the geo point value.
-     *
-     * @return array
-     */
-    public function getPoint()
-    {
-        return $this->point;
+        if ($lat && $lng) {
+            $this->point = [
+                'lat' => (float) $lat,
+                'lng' => (float) $lng,
+            ];
+        }
     }
 
     /**
      * return elasticsearch-friendly geo point format.
+     *
+     * Beware: Elastic uses lat/lon as keys. Google uses lat/lng.
      * 
      * @return array
      */
@@ -65,8 +59,6 @@ class GeoPoint implements JsonSerializable
             return null;
         }
 
-        // Beware:
-        // Elastic uses lat/lon as keys. Google uses lat/lng.
         return [
             'lat' => $this->point['lat'],
             'lon' => $this->point['lng'],
@@ -80,7 +72,7 @@ class GeoPoint implements JsonSerializable
      */
     public function toArray()
     {
-        return $this->point;
+        return $this->point ?: [];
     }
 
     /**
@@ -101,7 +93,7 @@ class GeoPoint implements JsonSerializable
     public function __toString()
     {
         if (empty($this->point)) {
-            return;
+            return '';
         }
 
         return $this->point['lat'].' '.$this->point['lng'];

--- a/src/GeoPoint.php
+++ b/src/GeoPoint.php
@@ -32,13 +32,13 @@ class GeoPoint implements JsonSerializable
      * @param float $lat Latitude
      * @param float $lng Longitude
      */
-    public function __construct($lat = 0, $lng = 0)
+    public function __construct($lat = null, $lng = null)
     {
-        if ($lat < -90.0 || $lat > 90.0 || $lng < -180.0 || $lng > 180.0) {
-            throw new \InvalidArgumentException('Given latitude longitude pair is invalid.');
-        }
-
         if ($lat && $lng) {
+            if ($lat < -90.0 || $lat > 90.0 || $lng < -180.0 || $lng > 180.0) {
+                throw new \InvalidArgumentException('Given latitude longitude pair is invalid.');
+            }
+
             $this->point = [
                 'lat' => (float) $lat,
                 'lng' => (float) $lng,
@@ -56,7 +56,7 @@ class GeoPoint implements JsonSerializable
     public function toElastic()
     {
         if (empty($this->point)) {
-            return null;
+            return [];
         }
 
         return [

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -36,8 +36,12 @@ class IpAddress
      *
      * @param string $addr IP address.
      */
-    public function __construct($addr)
+    public function __construct($addr = null)
     {
+        if (!$addr) {
+            return; // early..
+        }
+
         $filtered = filter_var($addr, FILTER_VALIDATE_IP);
         if ($filtered === false) {
             throw new \InvalidArgumentException('Given IP '.$addr.' is not a valid IP address');
@@ -53,6 +57,6 @@ class IpAddress
      */
     public function __toString()
     {
-        return $this->address;
+        return $this->address ?: '';
     }
 }

--- a/src/IpRange.php
+++ b/src/IpRange.php
@@ -44,7 +44,7 @@ class IpRange implements JsonSerializable
      * @param IpAddress $startIp
      * @param IpAddress $endIp
      */
-    public function __construct(IpAddress $startIp, IpAddress $endIp)
+    public function __construct(IpAddress $startIp = null, IpAddress $endIp = null)
     {
         $this->startIp = $startIp;
         $this->endIp   = $endIp;
@@ -90,10 +90,16 @@ class IpRange implements JsonSerializable
         return new IpRange(new IpAddress($start), new IpAddress($end));
     }
 
-    // Cast the range to a CIDR notation
+    /**
+     * String representation of a range.
+     * 
+     * Example output: "192.168.0.10 - 192.168.0.255"
+     *    
+     * @return string
+     */
     public function __toString()
     {
-        // TBD
+        return $this->isEmpty() ? '' : (string) $this->startIp.' - '. $this->endIp;
     }
 
     /**
@@ -103,10 +109,24 @@ class IpRange implements JsonSerializable
      */
     public function toArray()
     {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
         return [
             'startIp' => (string) $this->getStartIp(),
             'endIp'   => (string) $this->getEndIp(),
         ];
+    }
+
+    /**
+     * Returns boolean TRUE if the range is empty, false otherwise.
+     * 
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return $this->startIp === null || $this->endIp === null;
     }
 
     /**

--- a/tests/ColorTest.php
+++ b/tests/ColorTest.php
@@ -34,16 +34,25 @@ class ColorTest extends \PHPUnit_Framework_TestCase
     public function testRGBConversionWorks()
     {
         $color = new Color('FFF');
-        $this->assertEquals([255,255,255], $color->toRGB());
+        $this->assertEquals([255, 255, 255], $color->toRGB());
         $this->assertEquals('rgb(255,255,255)', $color->toRGBString());
-        $this->assertInstanceof(\JsonSerializable::class, $color);
+        $this->assertInstanceOf(\JsonSerializable::class, $color);
         $this->assertEquals($color->jsonSerialize(), $color->toArray());
     }
 
-    public function testFactory() 
+    public function testFactory()
     {
-        $color = Color::fromRGB(255,255,255);
+        $color = Color::fromRGB(255, 255, 255);
         $this->assertEquals('#FFFFFF', $color->toHex());
+    }
+
+    public function testEmptyState()
+    {
+        $color = new Color();
+        $this->assertInstanceOf(Color::class, $color);
+        $this->assertEquals([], $color->toArray());
+        $this->assertEquals([], $color->toRGB());
+        $this->assertEquals('', (string) $color);
     }
 
     /**
@@ -52,7 +61,7 @@ class ColorTest extends \PHPUnit_Framework_TestCase
     public function testSerializedColorHasAName($hex, $name)
     {
         $color = new Color($hex);
-        $arr = $color->toArray();
+        $arr   = $color->toArray();
         $this->assertEquals($arr['name'], $name);
     }
 

--- a/tests/DateRangeTest.php
+++ b/tests/DateRangeTest.php
@@ -13,19 +13,30 @@ use DDD\Embeddable\DateRange;
 
 class DateRangeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testDateRages()
+    public function testDateRanges()
     {
-        $start = new \DateTime('31 December 2016');
-        $end   = new \DateTime('1 January 2017');
+        $start    = new \DateTime('31 December 2016');
+        $end      = new \DateTime('1 January 2017');
+        $startStr = '2016-12-31T00:00:00+00:00';
+        $endStr   = '2017-01-01T00:00:00+00:00';
+        $obj      = new DateRange($start, $end);
 
-        $obj   = new DateRange($start, $end);
         $this->assertEquals('2016 - 2017', $obj->format('Y'));
         $this->assertEquals('2016-12 - 2017-01', $obj->format('Y-m'));
         $this->assertStringStartsWith('2016-12-31', $obj->format());
         $this->assertEquals(86400, $obj->getDurationInSeconds());
-        $this->assertEquals($obj->toArray(), ['start' => $start, 'end' => $end]);
-        $this->assertEquals($obj->jsonSerialize(), ['start' => $start, 'end' => $end]);
+        $this->assertEquals($obj->toArray(), ['start' => $startStr, 'end' => $endStr]);
+        $this->assertEquals($obj->jsonSerialize(), ['start' => $startStr, 'end' => $endStr]);
         $this->assertEquals((string) $obj, $start->format('c') . ' - ' . $end->format('c'));
+    }
+
+    public function testEmptyState()
+    {
+        $obj = new DateRange();
+        $this->assertInstanceOf(DateRange::class, $obj);
+        $this->assertEquals([], $obj->toArray());
+        $this->assertEquals('', (string) $obj);
+        $this->assertEquals(0, $obj->getDurationInSeconds());
     }
 
     public function testOlderDateRages()

--- a/tests/EmailAddressTest.php
+++ b/tests/EmailAddressTest.php
@@ -39,6 +39,12 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($localPart, $obj->getLocalPart());
     }
 
+    public function testEmptyState()
+    {
+        $addr = new EmailAddress();
+        $this->assertInstanceOf(EmailAddress::class, $addr);
+    }
+
     public function invalidEmailProvider()
     {
         return [

--- a/tests/FullnameTest.php
+++ b/tests/FullnameTest.php
@@ -50,6 +50,13 @@ class FullnameTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, json_encode($obj2));
     }
 
+    public function testEmptyState()
+    {
+        $name = new Fullname();
+        $this->assertInstanceOf(Fullname::class, $name);
+        $this->assertEquals('', (string) $name);
+    }
+
     /**
      * @return array
      */

--- a/tests/GeoPointTest.php
+++ b/tests/GeoPointTest.php
@@ -16,10 +16,8 @@ class GeoPointTest extends \PHPUnit_Framework_TestCase
     public function testValidGeoPoint()
     {
         $geoPoint = new GeoPoint(24, 34);
-        $this->assertEquals($geoPoint->getPoint(), ['lat' => 24, 'lng' => 34]);
         $this->assertEquals($geoPoint->toArray(), ['lat' => 24, 'lng' => 34]);
         $this->assertEquals($geoPoint->jsonSerialize(), ['lat' => 24, 'lng' => 34]);
-        $this->assertEquals((string) $geoPoint, '24 34');
         $this->assertEquals($geoPoint->toElastic(), ['lat' => 24, 'lon' => 34]);
     }
 
@@ -29,5 +27,23 @@ class GeoPointTest extends \PHPUnit_Framework_TestCase
     public function testInvalidGeoPoint()
     {
         $geoPoint = new GeoPoint(-300, 300);
+    }
+
+    public function testStringRepresentationAndEmptyState()
+    {
+        $point = new GeoPoint(41.520112, 29.453401);
+        $this->assertEquals((string) $point, '41.520112 29.453401');
+
+        $point = new GeoPoint();
+        $this->assertEquals(null, (string) $point);
+        $this->assertInternalType('array', $point->toArray());
+    }
+
+    public function testElasticsearchSupport()
+    {
+        $point   = new GeoPoint(41, 29);
+        $elastic = ['lat' => 41, 'lon' => 29];
+        $this->assertEquals($elastic, $point->toElastic());
+        $this->assertNotEquals($elastic, $point->toArray());
     }
 }

--- a/tests/GeoPointTest.php
+++ b/tests/GeoPointTest.php
@@ -29,6 +29,14 @@ class GeoPointTest extends \PHPUnit_Framework_TestCase
         $geoPoint = new GeoPoint(-300, 300);
     }
 
+    public function testEmptyState()
+    {
+        $p = new GeoPoint();
+        $this->assertInstanceOf(GeoPoint::class, $p);
+        $this->assertEquals([], $p->toArray());
+        $this->assertEquals([], $p->toElastic());
+    }
+
     public function testStringRepresentationAndEmptyState()
     {
         $point = new GeoPoint(41.520112, 29.453401);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -33,6 +33,13 @@ class IpAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, (string) $obj);
     }
 
+    public function testEmptyState()
+    {
+        $obj = new IpAddress();
+        $this->assertInstanceOf(IpAddress::class, $obj);
+        $this->assertSame('', (string) $obj);
+    }
+
     /**
      * ip data provider
      * 

--- a/tests/IpRangeTest.php
+++ b/tests/IpRangeTest.php
@@ -33,6 +33,14 @@ class IpRangeTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('endIp', $range->toArray());
     }
 
+    public function testStringRepresentationAndEmptyState()
+    {
+        $range = new IpRange();
+        $this->assertInstanceOf(IpRange::class, $range);
+        $this->assertEquals([], $range->toArray());
+        $this->assertEquals('', (string) $range);
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
- Returning an empty string in __toString sounds like more appropriate.
- Allow empty state since the mapped `$point` field is nullable
- Increase test coverage to %100
